### PR TITLE
fix: avoid list subscripted error on older Python

### DIFF
--- a/scripts/post_arxiv_na_issue.py
+++ b/scripts/post_arxiv_na_issue.py
@@ -6,6 +6,7 @@ import feedparser
 import requests
 from datetime import datetime, timezone
 from dateutil import parser as dtparser
+from typing import List
 
 ARXIV_API_URL = "http://export.arxiv.org/api/query"
 SEARCH_QUERY = '(cat:math.NA OR cat:cs.NA)'
@@ -155,7 +156,7 @@ def rule_based_summary(abstract: str):
 
 # ---------- Issue layout ----------
 
-def badges(cats: list[str]) -> str:
+def badges(cats: List[str]) -> str:
     tags = []
     for c in cats:
         if c == "math.NA": tags.append("`math.NA`")


### PR DESCRIPTION
## Summary
- import `List` from typing and use it for `badges` argument to support Python 3.8+

## Testing
- `python -m py_compile scripts/post_arxiv_na_issue.py`
- `pip install feedparser python-dateutil requests` *(fails: Cannot connect to proxy)*

------
https://chatgpt.com/codex/tasks/task_e_68a5d569fe808322b101fbc5ec291f9a