### PR TITLE
Fix permissions for Daily arXiv NA issue workflow

### DIFF
--- a/.github/workflows/arxiv_na_issue.yml
+++ b/.github/workflows/arxiv_na_issue.yml
@@ -5,6 +5,10 @@ on:
     - cron: '0 0 * * *'
   workflow_dispatch:
 
+permissions:
+  contents: read
+  issues: write
+
 jobs:
   build:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Summary
- grant issues write permission so manual workflow runs can update/create issue

## Testing
- `python -m py_compile scripts/post_arxiv_na_issue.py`


------
https://chatgpt.com/codex/tasks/task_e_68a6fc875ec483229cb889497395885d