### PR TITLE
Handle missing labels for Daily arXiv NA issue workflow

### DIFF
--- a/.github/workflows/arxiv_na_issue.yml
+++ b/.github/workflows/arxiv_na_issue.yml
@@ -5,6 +5,10 @@ on:
     - cron: '0 0 * * *'
   workflow_dispatch:
 
+permissions:
+  contents: read
+  issues: write
+
 jobs:
   build:
     runs-on: ubuntu-latest
@@ -14,7 +18,16 @@ jobs:
         with:
           python-version: '3.x'
       - name: Post today's arXiv NA papers
+        id: post
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           python scripts/post_arxiv_na_issue.py
+
+      - name: Comment workflow run link
+        if: ${{ steps.post.outputs.issue_number }}
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          gh api repos/${{ github.repository }}/issues/${{ steps.post.outputs.issue_number }}/comments \
+            -f body="Workflow run: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"

--- a/scripts/post_arxiv_na_issue.py
+++ b/scripts/post_arxiv_na_issue.py
@@ -2,7 +2,7 @@
 # -*- coding: utf-8 -*-
 
 import os, sys, time, textwrap, html, re, json
-import urllib.request, urllib.parse
+import urllib.request, urllib.parse, urllib.error
 from types import SimpleNamespace
 from datetime import datetime, timezone, timedelta
 from typing import List
@@ -31,14 +31,18 @@ def github_request(method: str, url: str, token: str, json_data=None):
         data_bytes = json.dumps(json_data).encode("utf-8")
         headers["Content-Type"] = "application/json"
     req = urllib.request.Request(url, data=data_bytes, headers=headers, method=method.upper())
-    with urllib.request.urlopen(req, timeout=30) as resp:
-        status = resp.getcode()
-        body = resp.read().decode()
-        if status >= 300:
-            raise RuntimeError(f"GitHub API error {status}: {body}")
-        if status == 204:
-            return {}
-        return json.loads(body)
+    try:
+        with urllib.request.urlopen(req, timeout=30) as resp:
+            status = resp.getcode()
+            body = resp.read().decode()
+    except urllib.error.HTTPError as e:
+        status = e.code
+        body = e.read().decode()
+    if status >= 300:
+        raise RuntimeError(f"GitHub API error {status}: {body}")
+    if status == 204:
+        return {}
+    return json.loads(body)
 
 # ---------- arXiv fetch & parse ----------
 
@@ -288,26 +292,53 @@ def build_issue_body(entries, date_str: str):
 # ---------- Issue upsert ----------
 
 def find_issue_by_title(repo: str, token: str, title: str):
-    url = f"https://api.github.com/repos/{repo}/issues?state=all&per_page=50"
-    data = github_request("GET", url, token)
-    for it in data:
-        if it.get("title") == title and "pull_request" not in it:
-            return it
-    return None
+    """Return the issue dict matching *title* if it exists.
+
+    The repository might have many issues/PRs, so iterate through pages
+    instead of only checking the first page. Stops after a page returns
+    fewer than 1 item (i.e., end of results).
+    """
+    page = 1
+    while True:
+        url = f"https://api.github.com/repos/{repo}/issues?state=all&per_page=100&page={page}"
+        data = github_request("GET", url, token)
+        if not data:
+            return None
+        for it in data:
+            if it.get("title") == title and "pull_request" not in it:
+                return it
+        page += 1
+
+def ensure_labels_exist(repo: str, token: str, labels):
+    for name in labels:
+        url = f"https://api.github.com/repos/{repo}/labels/{urllib.parse.quote(name)}"
+        try:
+            github_request("GET", url, token)
+        except RuntimeError as e:
+            if "404" in str(e):
+                github_request(
+                    "POST",
+                    f"https://api.github.com/repos/{repo}/labels",
+                    token,
+                    json_data={"name": name, "color": "c5def5"},
+                )
+            else:
+                raise
 
 def create_or_update_issue(repo: str, token: str, title: str, body: str, labels=None):
     labels = labels or []
+    ensure_labels_exist(repo, token, labels)
     existing = find_issue_by_title(repo, token, title)
     if existing:
         issue_url = existing["url"]
         current_labels = [l["name"] for l in existing.get("labels", [])]
         label_set = sorted(set(current_labels) | set(labels))
         github_request("PATCH", issue_url, token, json_data={"body": body, "labels": label_set})
-        return existing["html_url"]
+        return existing["html_url"], existing["number"]
     else:
         url = f"https://api.github.com/repos/{repo}/issues"
         data = github_request("POST", url, token, json_data={"title": title, "body": body, "labels": labels})
-        return data["html_url"]
+        return data["html_url"], data["number"]
 
 # ---------- main ----------
 
@@ -327,8 +358,15 @@ def main():
 
     body = build_issue_body(entries, target_date)
     title = f"arXiv NA - {target_date}"
-    url = create_or_update_issue(repo, token, title, body, labels=LABELS)
-    print(f"Done. Issue: {url}")
+    issue_url, issue_number = create_or_update_issue(repo, token, title, body, labels=LABELS)
+
+    gh_output = os.environ.get("GITHUB_OUTPUT")
+    if gh_output:
+        with open(gh_output, "a", encoding="utf-8") as fh:
+            fh.write(f"issue_number={issue_number}\n")
+            fh.write(f"issue_url={issue_url}\n")
+
+    print(f"Done. Issue: {issue_url}")
 
 if __name__ == "__main__":
     main()


### PR DESCRIPTION
## Summary
- handle HTTP errors from GitHub API
- auto-create missing labels before creating/updating issue
- search all pages when looking for existing issue to avoid duplicates
- comment workflow run link on created/updated issue via `gh` CLI step
- expose issue metadata through `$GITHUB_OUTPUT`

## Testing
- `python -m py_compile scripts/post_arxiv_na_issue.py`


------
https://chatgpt.com/codex/tasks/task_e_68a6fc875ec483229cb889497395885d