### PR TITLE
Fix formula rendering inside collapsed comments

### DIFF
--- a/scripts/post_arxiv_na_issue.py
+++ b/scripts/post_arxiv_na_issue.py
@@ -297,7 +297,7 @@ def build_issue_body(entries, date_str: str):
             details.append(abstract_raw.strip() + "\n")
         if key_math:
             details.append("**Key formula**\n\n")
-            details.append(key_math + "\n")
+            details.append(key_math + "\n\n")
         details.append("</details>\n")
         out.append("\n".join(details))
 


### PR DESCRIPTION
## Summary
- add a blank line after key formula blocks to let GitHub render LaTeX inside `<details>` sections

## Testing
- `python -m py_compile scripts/post_arxiv_na_issue.py`


------
https://chatgpt.com/codex/tasks/task_e_68a710049ca483228e66b234a2985302